### PR TITLE
fix(ci): correct workflow_run names + harden the workflow bundle

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -2,7 +2,7 @@ name: Bump version
 
 on:
   workflow_run:
-    workflows: ["ci"]
+    workflows: ["Code Quality and Tests"]  # the name: in ci.yml, not the filename
     branches: [main]
     types:
       - completed

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -20,12 +20,20 @@ jobs:
         with:
           fetch-depth: 0
           token: "${{ secrets.COMMITIZEN_TOKEN }}"
+      - name: Detect bumpable commits
+        id: bump_check
+        continue-on-error: true
+        run: |
+          pipx install commitizen
+          cz bump --dry-run
       - name: Create bump and changelog
+        if: steps.bump_check.outcome == 'success'
         uses: commitizen-tools/commitizen-action@master
         with:
           github_token: ${{ secrets.COMMITIZEN_TOKEN }}
           changelog_increment_filename: body.md
       - name: Release
+        if: steps.bump_check.outcome == 'success'
         uses: ncipollo/release-action@v1
         with:
           tag: v${{ env.REVISION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,20 +4,19 @@ on:
   push:
     branches: [ main, dev ]
     paths-ignore:
-      - 'VERSION'
       - 'pyproject.toml'
       - 'CHANGELOG.md'
       - '.github/workflows/**'
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Run tests for a specific version'
-        required: false
   pull_request:
     branches: [ main, dev ]
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -43,7 +42,7 @@ jobs:
       run: uv python install ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: uv sync --group dev --group examples --group app
+      run: uv sync
 
     - name: Test with pytest
       run: uv run pytest --cov --cov-report=xml --cov-report=term-missing
@@ -54,7 +53,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
-        fail_ci_if_error: false
+        fail_ci_if_error: true
 
     - name: Minimize uv cache
       run: uv cache prune --ci
@@ -78,7 +77,7 @@ jobs:
       run: uv python install 3.14
 
     - name: Install dependencies
-      run: uv sync --group dev
+      run: uv sync
 
     - name: Lint with ruff
       run: uv run ruff check .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Publish docs via GitHub Pages
 on:
   workflow_run:
-    workflows: ["bumpversion"]
+    workflows: ["Bump version"]  # the name: in bumpversion.yml, not the filename
     branches: [main]
     types:
       - completed

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,8 +7,7 @@ on:
       - completed
 
 permissions:
-  contents: read
-  pages: write
+  contents: write
 
 jobs:
   build:
@@ -17,9 +16,11 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0
+          token: ${{ secrets.MKDOCS_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -29,13 +30,10 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Set up Python
-        run: uv python install 3.13
+        run: uv python install 3.14
 
-      - name: Export docs requirements
-        run: uv export --group docs --no-hashes --output-file docs/requirements.txt
+      - name: Install dependencies
+        run: uv sync
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.MKDOCS_TOKEN }}
-          REQUIREMENTS: docs/requirements.txt
+        run: uv run mkdocs gh-deploy --force


### PR DESCRIPTION
## Why
`workflow_run` matches a workflow's `name:`, not its filename — so the CI → bump → docs chain never fired (`bumpversion` waited on `ci`, docs on `bumpversion`). Plus an audit surfaced several latent issues, notably that the docs deploy would fail building river's Rust extension in a Rust-less container.

## Changes
**Chain wiring**
- `bumpversion.yml`: `workflows: ["ci"]` → `["Code Quality and Tests"]`
- `docs.yml`: `workflows: ["bumpversion"]` → `["Bump version"]`

**ci.yml**
- codecov `fail_ci_if_error: true` (token refreshed; surface upload failures)
- drop unused `workflow_dispatch` input and vestigial `VERSION` paths-ignore
- `uv sync` (default-groups already cover dev/app/docs/examples)
- add `concurrency` to cancel superseded runs

**bumpversion.yml**
- gate bump+release on `cz bump --dry-run` so routine merges with no bumpable commits stay green instead of going red

**docs.yml**
- build on the runner with `uv sync` + `uv run mkdocs gh-deploy --force` (Rust present) instead of the `mkdocs-deploy-gh-pages` Docker action (no Rust → editable river build fails)
- Python 3.14 (was 3.13, below `requires-python`); pin `checkout@v4` (was `@main`)

## Notes
- Requires `COMMITIZEN_TOKEN` (PAT, repo write) and `MKDOCS_TOKEN` (gh-pages push) secrets; `CODECOV_TOKEN` already refreshed.
- `docs.yml` only fires after a version bump and has never run before — first real run will be its trial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)