### PR TITLE
fix(docs): deploy gh-pages with GITHUB_TOKEN (stale MKDOCS_TOKEN)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     types:
       - completed
+  workflow_dispatch:  # allow manual docs deploy
 
 permissions:
   contents: write
@@ -20,7 +21,8 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-          token: ${{ secrets.MKDOCS_TOKEN }}
+          # default GITHUB_TOKEN (has contents: write above) pushes gh-pages;
+          # no PAT needed (the old MKDOCS_TOKEN was stale -> push 128)
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
Docs built fine; the gh-pages push failed (128) on the stale MKDOCS_TOKEN PAT. Push with the workflow's built-in GITHUB_TOKEN (contents: write) instead. Adds workflow_dispatch for manual deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)