### PR TITLE
fix(ci): version bump never ran (cz prompt EOFError) + robust docs trigger

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -25,7 +25,9 @@ jobs:
         continue-on-error: true
         run: |
           pipx install commitizen
-          cz bump --dry-run
+          # --yes: non-interactive (without it cz prompts -> EOFError on CI ->
+          # the gate always "failed" and the bump was always skipped).
+          cz bump --yes --dry-run
       - name: Create bump and changelog
         if: steps.bump_check.outcome == 'success'
         uses: commitizen-tools/commitizen-action@master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4


### PR DESCRIPTION
Root cause of 'no releases': the bump-detection gate ran `cz bump --dry-run` which prompts interactively, hitting EOFError on CI, so the gate always failed and the bump+release were always skipped. Add `--yes`. Also let docs deploy on `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)