### PR TITLE
fix(ci): release with GITHUB_TOKEN (expired COMMITIZEN_TOKEN -> 403)

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: "${{ secrets.COMMITIZEN_TOKEN }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Detect bumpable commits
         id: bump_check
         continue-on-error: true
@@ -32,7 +32,7 @@ jobs:
         if: steps.bump_check.outcome == 'success'
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: ${{ secrets.COMMITIZEN_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           changelog_increment_filename: body.md
       - name: Release
         if: steps.bump_check.outcome == 'success'
@@ -41,4 +41,4 @@ jobs:
           tag: v${{ env.REVISION }}
           bodyFile: "body.md"
           skipIfReleaseExists: true
-          token: ${{ secrets.COMMITIZEN_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump computed 4.0.1 then failed pushing to main (403): the COMMITIZEN_TOKEN PAT is expired. main has no protection, so use the built-in GITHUB_TOKEN (contents: write). No PAT to maintain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)