### PR TITLE
ci: skip test matrix for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,21 @@ on:
   push:
     branches: [ main, dev ]
     paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
       - 'pyproject.toml'
       - 'CHANGELOG.md'
       - '.github/workflows/**'
   workflow_dispatch:
   pull_request:
     branches: [ main, dev ]
+    # Skip the heavy test matrix for docs-only changes. Safe here because
+    # main has no required status checks, so a skipped run never blocks merge.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
 
 permissions:
   contents: read


### PR DESCRIPTION
`pull_request` had no path filter, so docs-only PRs (e.g. #24, a one-line README change) ran the full 3-OS matrix. This adds a docs `paths-ignore` (`**/*.md`, `docs/**`, `LICENSE`) to `pull_request` and aligns `push`.

Safe because `main` has no required status checks — a skipped run can't block merge. Mixed code+docs PRs still run (any non-ignored path triggers).