### PR TITLE
ci: cache Rust build + bump actions to Node 24

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -16,7 +16,7 @@ jobs:
     name: "Bump version and create changelog with commitizen"
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,21 @@ on:
   push:
     branches: [ main, dev ]
     paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
       - 'pyproject.toml'
       - 'CHANGELOG.md'
       - '.github/workflows/**'
   workflow_dispatch:
   pull_request:
     branches: [ main, dev ]
+    # Skip the heavy test matrix for docs-only changes. Safe here because
+    # main has no required status checks, so a skipped run never blocks merge.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,29 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.14"]
 
+    # Build river's two Rust extensions into one dir we can cache. uv rebuilds
+    # editable path deps every run, so without this cargo recompiles MKL + all
+    # crate deps from scratch on each job/OS.
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/rust-target
+
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
 
+    - name: Cache Rust build
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ${{ github.workspace }}/rust-target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('vendor/river/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-
+
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v6
       with:
         version: "latest"
         enable-cache: true
@@ -73,13 +89,26 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/rust-target
+
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
 
+    - name: Cache Rust build
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ${{ github.workspace }}/rust-target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('vendor/river/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-
+
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v6
       with:
         version: "latest"
         enable-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0
@@ -25,7 +25,7 @@ jobs:
           # no PAT needed (the old MKDOCS_TOKEN was stale -> push 128)
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true


### PR DESCRIPTION
## Caching (the slow part)
`vendor/river` is an editable path dep with two setuptools-rust extensions (`_rust_stats`, `_rust_decomp`) built against MKL/BLAS. uv rebuilds editables every run, so cargo recompiled MKL + all crate deps **from scratch in both lint and test, on every OS**. The uv download cache doesn't cover cargo artifacts.

- Pin `CARGO_TARGET_DIR` to one dir so both crates' output lands together
- `actions/cache@v4` on `~/.cargo/registry`, `~/.cargo/git`, and that target dir, keyed on `vendor/river/Cargo.lock` (per-OS)

First run on each OS/lockfile populates the cache; subsequent runs restore it and cargo only relinks the river crate. Shared across lint + test runs on the same OS.

## Node 20 deprecation
Bump `actions/checkout@v4→v5` and `astral-sh/setup-uv@v5→v6` (Node 24) across ci/bumpversion/docs.

No version bump (`ci:`).